### PR TITLE
get_or_create_metric

### DIFF
--- a/app_metrics/tests/base_tests.py
+++ b/app_metrics/tests/base_tests.py
@@ -13,13 +13,29 @@ from app_metrics.trending import _trending_for_current_day, _trending_for_yester
 class MetricCreationTests(TestCase): 
    
     def test_metric(self): 
-
         new_metric = create_metric(name='Test Metric Class',
                                    slug='test_metric')
 
         metric('test_metric')
         metric('test_metric')
         metric('test_metric')
+
+        current_count = MetricItem.objects.filter(metric=new_metric)
+        self.assertEqual(len(current_count), 3)
+        self.assertEqual(current_count[0].num, 1)
+        self.assertEqual(current_count[1].num, 1)
+        self.assertEqual(current_count[2].num, 1)
+
+    def test_get_or_create_metric(self):
+        new_metric = get_or_create_metric(name='Test Metric Class',
+                                          slug='test_metric')
+
+        metric('test_metric')
+        metric('test_metric')
+        metric('test_metric')
+
+        new_metric = get_or_create_metric(name='Test Metric Class',
+                                          slug='test_metric')
 
         current_count = MetricItem.objects.filter(metric=new_metric)
         self.assertEqual(len(current_count), 3)
@@ -193,3 +209,4 @@ class EmailTests(TestCase):
         management.call_command('metrics_send_mail')
 
         self.assertEqual(len(mail.outbox), 1)
+

--- a/app_metrics/utils.py
+++ b/app_metrics/utils.py
@@ -53,6 +53,16 @@ def create_metric(name, slug):
         new_metric.save()
         return new_metric 
 
+def get_or_create_metric(name, slug):
+    """ Returns the metric with the given name and slug, creating it if necessary """
+
+    backend = get_backend() 
+    if backend == 'app_metrics.backends.mixpanel': 
+        return 
+    
+    metric, created = Metric.objects.get_or_create(name=name, slug=slug)
+    return metric
+
 class InvalidMetricsBackend(Exception): pass 
 class MetricError(Exception): pass 
 
@@ -93,3 +103,4 @@ def get_previous_month(date):
 def get_previous_year(date): 
     new = date 
     return new.replace(year=new.year-1)
+


### PR DESCRIPTION
Method get_or_create_metric on utils.
I found it useful since it prevents me from calling create_metric every time I introduce a new metric.
