### PR TITLE
Update app_metrics/backends/redis.py

### DIFF
--- a/app_metrics/backends/redis.py
+++ b/app_metrics/backends/redis.py
@@ -2,8 +2,8 @@
 from django.conf import settings
 from app_metrics.tasks import redis_metric_task, redis_gauge_task
 
-def metric(slug, num=1, properties=None):
-    redis_metric_task.delay(slug, num, properties)
+def metric(slug, num=1, properties={}):
+    redis_metric_task.delay(slug, num, **properties)
 
 def timing(slug, seconds_taken, **kwargs):
     # No easy way to do this with redis, so this is a no-op


### PR DESCRIPTION
I'm trying out app_metrics backed by celery and redis, and I'm getting this exception in celery:

```
Task app_metrics.tasks.redis_metric_task[7355cd97-bda0-4e88-b4e7-c1cb960b67c8] raised
exception: TypeError('redis_metric_task() takes at most 2 arguments (3 given)',)
```

Should `properties` be a mapping here instead of `None`? Does the redis backend even support additional properties for metrics? I'm still trying to wrap my head around all this, so please forgive me if I'm asking silly questions ;)
