### PR TITLE
Support for swappable User model in Django 1.5

### DIFF
--- a/app_metrics/models.py
+++ b/app_metrics/models.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models, IntegrityError
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
@@ -35,7 +35,8 @@ class MetricSet(models.Model):
     """ A set of metrics that should be sent via email to certain users """
     name = models.CharField(_('name'), max_length=50)
     metrics = models.ManyToManyField(Metric, verbose_name=_('metrics'))
-    email_recipients = models.ManyToManyField(User, verbose_name=_('email recipients'))
+    email_recipients = models.ManyToManyField(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
+                                              verbose_name=_('email recipients'))
     no_email = models.BooleanField(_('no e-mail'), default=False)
     send_daily = models.BooleanField(_('send daily'), default=True)
     send_weekly = models.BooleanField(_('send weekly'), default=False)


### PR DESCRIPTION
This doesn't do anything about migrations for existing installation (which I don't think is possible, since you don't know what they have migrated to), but allows new installations to work correctly with Django 1.5 and a swapped out User model.

Should be completely backwards compatible.

Thanks!
