### PR TITLE
Update librato backend to latest Librato bindings.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,12 +114,10 @@ gauge() aspects, but not timer aspects of app_metrics.
 
 ``app_metrics.backends.librato_backend`` - This backend lets you send metrics to
 Librato. See the `Librato documentation`_ for more information on their API.
-This requires the `Librato library`_. It uses use a librato Gauge by default,
-although this can be overridden by supplying ``metric_type="counter"`` as a
-keyword arg to ``metric()``.
+This requires the `Librato library`_.
 
 .. _`Librato documentation`: http://dev.librato.com/v1/metrics#metrics
-.. _`Librato library`: http://pypi.python.org/pypi/librato/0.2
+.. _`Librato library`: http://pypi.python.org/pypi/librato-metrics
 
 ``app_metrics.backends.composite`` - This backend lets you compose multiple
 backends to which metric-calls are handed. The backends to which the call is

--- a/app_metrics/backends/librato.py
+++ b/app_metrics/backends/librato.py
@@ -6,7 +6,7 @@ def _get_func(async):
 
 
 def metric(slug, num=1, async=True, **kwargs):
-    _get_func(async)(slug, num, metric_type="counter", **kwargs)
+    _get_func(async)(slug, num, type="counter", **kwargs)
 
 
 def timing(slug, seconds_taken, async=True, **kwargs):
@@ -14,4 +14,4 @@ def timing(slug, seconds_taken, async=True, **kwargs):
 
 
 def gauge(slug, current_value, async=True, **kwargs):
-    _get_func(async)(slug, current_value, metric_type="gauge", **kwargs)
+    _get_func(async)(slug, current_value, type="gauge", **kwargs)

--- a/app_metrics/tasks.py
+++ b/app_metrics/tasks.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     librato = None
 
+
 class MixPanelTrackError(Exception):
     pass
 
@@ -71,7 +72,6 @@ def _get_token():
 
 @task
 def mixpanel_metric_task(slug, num, properties=None, **kwargs):
-
     token = _get_token()
     if properties is None:
         properties = dict()
@@ -112,6 +112,7 @@ def statsd_metric_task(slug, num=1, **kwargs):
     counter = statsd.Counter(slug, connection=conn)
     counter += num
 
+
 @task
 def statsd_timing_task(slug, seconds_taken=1.0, **kwargs):
     conn = get_statsd_conn()
@@ -144,6 +145,7 @@ def get_redis_conn():
     )
     return conn
 
+
 @task
 def redis_metric_task(slug, num=1, **kwargs):
     # Record a metric in redis. We prefix our key here with 'm' for Metric
@@ -163,6 +165,7 @@ def redis_metric_task(slug, num=1, **kwargs):
     r.incrby(month_key, num)
     r.incrby(year_key, num)
 
+
 @task
 def redis_gauge_task(slug, current_value, **kwargs):
     # We prefix our keys with a 'g' here for Gauge to avoid issues
@@ -173,14 +176,7 @@ def redis_gauge_task(slug, current_value, **kwargs):
 # Librato tasks
 
 @task
-def librato_metric_task(name, num, attributes=None, metric_type="gauge",
-                        **kwargs):
-    connection = librato.connect(settings.APP_METRICS_LIBRATO_USER,
-                                 settings.APP_METRICS_LIBRATO_TOKEN)
-
-    if metric_type == "counter":
-        metric = LibratoCounter(connection, name, attributes=attributes)
-    else:
-        metric = LibratoGauge(connection, name, attributes=attributes)
-
-    metric.add(num, source=settings.APP_METRICS_LIBRATO_SOURCE)
+def librato_metric_task(name, num, **kwargs):
+    api = librato.connect(settings.APP_METRICS_LIBRATO_USER,
+                          settings.APP_METRICS_LIBRATO_TOKEN)
+    api.submit(name, num, **kwargs)


### PR DESCRIPTION
I've updated librato backend to the latest librato bindings: https://github.com/librato/python-librato.
You already have pull-request from drio(https://github.com/frankwiles/django-app-metrics/pull/31), but his pull-request doesn't fix tasks for the backend.
My fix has natural behavior for metric(...) and gauge(...) methods:
-  metric(...) creates and updates a counter;
-  gauge(...) creates and submits a gauge value.
