### PR TITLE
fixed should_create_models() for composite backend

### DIFF
--- a/app_metrics/utils.py
+++ b/app_metrics/utils.py
@@ -89,7 +89,7 @@ def get_or_create_metric(name, slug):
     if not should_create_models():
         return
 
-    metric, created = Metric.objects.get_or_create(name=name, slug=slug)
+    metric, created = Metric.objects.get_or_create(slug=slug, defaults={'name': name})
     return metric
 
 


### PR DESCRIPTION
When using a composite backend (with a database backend inside), should_create_models() fails because it expects 'app_metrics.backends.db'

Now should_create_models inspects the APP_METRICS_COMPOSITE_BACKENDS values before giving up.
