### PR TITLE
Tests and Librato fixes

### DIFF
--- a/app_metrics/tasks.py
+++ b/app_metrics/tasks.py
@@ -179,4 +179,5 @@ def redis_gauge_task(slug, current_value, **kwargs):
 def librato_metric_task(name, num, **kwargs):
     api = librato.connect(settings.APP_METRICS_LIBRATO_USER,
                           settings.APP_METRICS_LIBRATO_TOKEN)
-    api.submit(name, num, **kwargs)
+    source = settings.APP_METRICS_LIBRATO_SOURCE
+    api.submit(name, num, source=source, **kwargs)


### PR DESCRIPTION
Tests were failing in Django 1.6 because transaction was not being rolled back when the database threw an IntegrityError. Fixed by wrapping save in an atomic block and using a no-op context manager when atomic is not available (Django < 1.6). 

Source was not being included in metrics sent to librato. Fixed by setting source kwarg to value provided by APP_METRICS_LIBRATO_SOURCE

Feedback appreciated.