### PR TITLE
Remove current day data from weekly metrics

### DIFF
--- a/app_metrics/templates/app_metrics/email.html
+++ b/app_metrics/templates/app_metrics/email.html
@@ -42,7 +42,6 @@
     {% for m in metrics %}
     <tr>
         <td>{{ m.metric.name }}</td>
-        <td>{{ m.trends.current_day }}</td>
         <td>{{ m.trends.week.week }}</td>
         <td>{{ m.trends.week.previous_week }}</td>
         <td>{{ m.trends.week.previous_month_week }}</td>


### PR DESCRIPTION
The table markup is broken, and current day metrics don't seem to fit with the weekly statistics.