### PR TITLE
Update to add timezone support.

### DIFF
--- a/app_metrics/management/commands/move_to_mixpanel.py
+++ b/app_metrics/management/commands/move_to_mixpanel.py
@@ -2,7 +2,8 @@ from django.core.management.base import NoArgsCommand
 
 from app_metrics.models import MetricItem
 from app_metrics.backends.mixpanel import metric
-from app_metrics.utils import get_backend
+from app_metrics.utils import get_backend, get_timestamp
+
 
 class Command(NoArgsCommand):
     help = "Move MetricItems from the db backend to MixPanel"
@@ -23,7 +24,7 @@ class Command(NoArgsCommand):
 
         for i in items:
             properties = {
-                'time': i.created.strftime('%s'),
+                'time': int(get_timestamp(i.created)),
             }
             metric(i.metric.slug, num=i.num, properties=properties)
 

--- a/app_metrics/models.py
+++ b/app_metrics/models.py
@@ -3,6 +3,7 @@ import datetime
 from django.db import models, IntegrityError
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
 
 from app_metrics.compat import User
 
@@ -55,7 +56,7 @@ class MetricItem(models.Model):
     """ Individual metric items """
     metric = models.ForeignKey(Metric, verbose_name=_('metric'))
     num = models.IntegerField(_('number'), default=1)
-    created = models.DateTimeField(_('created'), default=datetime.datetime.now)
+    created = models.DateTimeField(_('created'), default=timezone.datetime.now)
 
     class Meta:
         verbose_name = _('metric item')
@@ -146,8 +147,8 @@ class Gauge(models.Model):
     name = models.CharField(_('name'), max_length=50)
     slug = models.SlugField(_('slug'), unique=True, max_length=60)
     current_value = models.DecimalField(_('current value'), max_digits=15, decimal_places=6, default='0.00')
-    created = models.DateTimeField(_('created'), default=datetime.datetime.now)
-    updated = models.DateTimeField(_('updated'), default=datetime.datetime.now)
+    created = models.DateTimeField(_('created'), default=timezone.datetime.now)
+    updated = models.DateTimeField(_('updated'), default=timezone.datetime.now)
 
     class Meta:
         verbose_name = _('gauge')
@@ -160,5 +161,5 @@ class Gauge(models.Model):
         if not self.id and not self.slug:
             self.slug = slugify(self.name)
 
-        self.updated = datetime.datetime.now()
+        self.updated = timezone.datetime.now()
         return super(Gauge, self).save(*args, **kwargs)

--- a/app_metrics/utils.py
+++ b/app_metrics/utils.py
@@ -3,6 +3,7 @@ import datetime
 import time
 from django.conf import settings
 from django.utils.importlib import import_module
+from django.utils import timezone
 
 from app_metrics.exceptions import InvalidMetricsBackend, TimerError
 from app_metrics.models import Metric, MetricSet
@@ -227,3 +228,17 @@ def get_previous_year(date):
     new = date
     return new.replace(year=new.year-1)
 
+def timedelta_total_seconds(timedelta):
+    return timedelta.seconds + timedelta.days * 24 * 3600
+
+def get_timestamp(dt):
+    if dt.tzinfo is None:
+        return time.mktime((dt.year, dt.month, dt.day,
+                             dt.hour, dt.minute, dt.second,
+                             -1, -1, -1))
+    else:
+        timedelta = dt - datetime.datetime(1970, 1, 1, tzinfo=timezone.utc)
+        try:
+            return timedelta.total_seconds()
+        except AttributeError:
+            return timedelta_total_seconds(timedelta)


### PR DESCRIPTION
In order to avoid timezone support warnings, change default values for
metric items and gauges to timezone aware equivalents from
django.utils.timezone.

This requires some changes to move_to_mixpanel command so timestamps can
be calculated correctly. To support more platforms, changed the use of
strftime('%s') to a more compatible implementation that closely follows
the Python 3 implementation of timestamp().

Added timedelta_total_seconds() to allow continued support for Python
2.6.

Added tests for timestamp utility functions.